### PR TITLE
[exports] Use "require" instead of "module-sync", reorder "types"

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "type": "module",
   "exports": {
     ".": {
+      "types": "./src/nullthrows.ts",
       "import": "./build/nullthrows.js",
-      "module-sync": "./build/nullthrows.js",
-      "types": "./src/nullthrows.ts"
+      "require": "./build/nullthrows.js"
     }
   },
   "files": [


### PR DESCRIPTION
"module-sync" was meant to be transitional but modern Node supports loading ESM files listed under "require" when requiring an ESM package from CJS. Tested by creating a test CJS package and loading an `npm pack`'d version of this package.

"types" should go first in the exports.